### PR TITLE
Do not crash when channel does not have any playlists

### DIFF
--- a/youtube_up/uploader.py
+++ b/youtube_up/uploader.py
@@ -342,7 +342,7 @@ class YTUploaderSession:
         r.raise_for_status()
         return {
             playlist["title"]: playlist["playlistId"]
-            for playlist in r.json()["playlists"]
+            for playlist in r.json().get("playlists", [])
         }
 
     def _create_playlist(


### PR DESCRIPTION
For a YouTube account that does not (yet) have any playlists, the API response will not contain a `playlists` field, leading to KeyError.